### PR TITLE
Removing old statements to execute

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <psalm
-        totallyTyped="false"
         errorLevel="2"
         resolveFromConfigFile="true"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -23,7 +23,7 @@ final class Configuration implements ConfigurationInterface
             ->children()
                 ->enumNode('driver')
                     ->defaultValue('doctrine')
-                    ->values(['doctrine'/*, 'redis'*/])
+                    ->values(['doctrine'/* , 'redis' */])
                     ->validate()
                         ->ifTrue(static fn (string $value): bool => 'doctrine' === $value && !class_exists(DBALConnection::class))
                         ->thenInvalid('Package doctrine/dbal and doctrine/doctrine-bundle are required to use doctrine driver.')

--- a/src/Storage/Doctrine/Connection.php
+++ b/src/Storage/Doctrine/Connection.php
@@ -150,10 +150,6 @@ class Connection
         }
 
         $this->addTableToSchema($schema);
-
-        foreach ($schema->toSql($this->driverConnection->getDatabasePlatform()) as $sql) {
-            $this->driverConnection->executeStatement($sql);
-        }
     }
 
     /**

--- a/src/Storage/Doctrine/Connection.php
+++ b/src/Storage/Doctrine/Connection.php
@@ -152,6 +152,15 @@ class Connection
         $this->addTableToSchema($schema);
     }
 
+    public function executeSchema(Schema $schema, DBALConnection $forConnection): void
+    {
+        $this->configureSchema($schema, $forConnection);
+
+        foreach ($schema->toSql($this->driverConnection->getDatabasePlatform()) as $sql) {
+            $this->driverConnection->executeStatement($sql);
+        }
+    }
+
     /**
      * @return Result&ResultStatement
      */

--- a/tests/FunctionalTests/AbstractFunctionalTests.php
+++ b/tests/FunctionalTests/AbstractFunctionalTests.php
@@ -51,7 +51,7 @@ abstract class AbstractFunctionalTests extends WebTestCase
         try {
             $connection->executeQuery('TRUNCATE TABLE messenger_monitor');
         } catch (\Throwable) {
-            self::getContainer()->get('test.symfonycasts.messenger_monitor.storage.doctrine_connection')->configureSchema(new Schema(), $connection);
+            self::getContainer()->get('test.symfonycasts.messenger_monitor.storage.doctrine_connection')->executeSchema(new Schema(), $connection);
         }
 
         $this->messageBus = self::getContainer()->get('test.messenger.bus.default');

--- a/tests/IntegrationTests/AbstractDoctrineIntegrationTests.php
+++ b/tests/IntegrationTests/AbstractDoctrineIntegrationTests.php
@@ -40,7 +40,7 @@ abstract class AbstractDoctrineIntegrationTests extends KernelTestCase
         try {
             $connection->executeQuery('TRUNCATE TABLE messenger_monitor');
         } catch (\Throwable) {
-            $this->doctrineConnection->configureSchema(new Schema(), $connection);
+            $this->doctrineConnection->executeSchema(new Schema(), $connection);
         }
     }
 }


### PR DESCRIPTION
I believe this is left over back from when we auto-created the table. But now, this is called from a Doctrine schema listener, where we simply want to modify the schema.