### PR TITLE
Making CreateSchemaListener lazy to avoid circular reference

### DIFF
--- a/src/Resources/config/doctrine.xml
+++ b/src/Resources/config/doctrine.xml
@@ -40,6 +40,9 @@
         </service>
 
         <service id="symfonycasts.messenger_monitor.doctrine_listener.create_schema" class="SymfonyCasts\MessengerMonitorBundle\Storage\Doctrine\EventListener\CreateSchemaListener">
+            <argument type="service_locator">
+                <argument key="SymfonyCasts\MessengerMonitorBundle\Storage\Doctrine\Connection" type="service" id="symfonycasts.messenger_monitor.storage.doctrine_connection"/>
+            </argument>
             <argument type="service" id="symfonycasts.messenger_monitor.storage.doctrine_connection"/>
             <tag name="doctrine.event_subscriber"/>
         </service>

--- a/src/Storage/Doctrine/EventListener/CreateSchemaListener.php
+++ b/src/Storage/Doctrine/EventListener/CreateSchemaListener.php
@@ -7,6 +7,7 @@ namespace SymfonyCasts\MessengerMonitorBundle\Storage\Doctrine\EventListener;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
 use Doctrine\ORM\Tools\ToolEvents;
+use Psr\Container\ContainerInterface;
 use SymfonyCasts\MessengerMonitorBundle\Storage\Doctrine\Connection;
 
 /**
@@ -14,13 +15,13 @@ use SymfonyCasts\MessengerMonitorBundle\Storage\Doctrine\Connection;
  */
 final class CreateSchemaListener implements EventSubscriber
 {
-    public function __construct(private Connection $connection)
+    public function __construct(private ContainerInterface $container)
     {
     }
 
     public function postGenerateSchema(GenerateSchemaEventArgs $event): void
     {
-        $this->connection->configureSchema(
+        $this->container->get(Connection::class)->configureSchema(
             $event->getSchema(),
             $event->getEntityManager()->getConnection()
         );


### PR DESCRIPTION
When using the bundle, we had a circular reference in the container. In order to create the entity manager, `CreateSchemaListener` must be created... which requires the `Connection` object from this bundle... which then would require the EntityManager/registry. Not sure why it doesn't happen in these tests (but happens in our project's tests), but seems easy enough to fix.