### PR TITLE
Shortening class name to make space for table

### DIFF
--- a/src/Resources/views/blocks/_statistics_per_message.html.twig
+++ b/src/Resources/views/blocks/_statistics_per_message.html.twig
@@ -16,7 +16,7 @@
         <tbody>
         {% for metrics in statistics.metrics %}
             <tr>
-                <td>{{ metrics.class }}</td>
+                <td title="{{ metrics.class }}">{{ metrics.shortClassName }}</td>
                 <td>{{ metrics.messagesCount }}</td>
                 <td>{{ metrics.messagesHandledPerHour }}</td>
                 <td>{{ metrics.averageWaitingTime|time }}</td>

--- a/src/Statistics/MetricsPerMessageType.php
+++ b/src/Statistics/MetricsPerMessageType.php
@@ -24,6 +24,11 @@ final class MetricsPerMessageType
         return $this->class;
     }
 
+    public function getShortClassName(): string
+    {
+        return basename(str_replace('\\', '/', $this->class));
+    }
+
     public function getMessagesCount(): int
     {
         return $this->messagesCountOnPeriod;

--- a/tests/Statistics/MetricsPerMessageTypeTest.php
+++ b/tests/Statistics/MetricsPerMessageTypeTest.php
@@ -15,6 +15,12 @@ final class MetricsPerMessageTypeTest extends TestCase
         $this->assertSame('Message', $metrics->getClass());
     }
 
+    public function testGetShortClassName(): void
+    {
+        $metrics = new MetricsPerMessageType(new \DateTimeImmutable(), new \DateTimeImmutable(), self::class, 0, 0, 0);
+        $this->assertSame('MetricsPerMessageTypeTest', $metrics->getShortClassName());
+    }
+
     public function testMessagesCount(): void
     {
         $metrics = new MetricsPerMessageType(new \DateTimeImmutable(), new \DateTimeImmutable(), 'Message', 10, 0, 0);


### PR DESCRIPTION
Otherwise the table gets HUGE horizontally and goes way off the page.