### PR TITLE
require friendsofphp/php-cs-fixer and use in ci + workflow improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,14 +96,6 @@ jobs:
           coverage: none
           php-version: ${{ matrix.php }}
 
-      - name: "Verify MariaDB connection"
-        env:
-          PORT: ${{ job.services.mariadb.ports[3306] }}
-        run: |
-          while ! mysqladmin ping -h"127.0.0.1" -P"$PORT" --silent; do
-            sleep 1
-          done
-
       - name: "Install dependencies with composer"
         uses: ramsey/composer-install@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,10 @@
 name: MessengerMonitorBundle CI
+
 on:
   pull_request: ~
   push:
     branches:
-      - master
+      - "master"
 
 jobs:
   coding-standards:
@@ -35,18 +36,18 @@ jobs:
   build:
     name: "Unit Tests"
 
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-latest"
 
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - php: '8.0'
-          - php: '8.1'
-          - php: '8.0'
-            mode: low-deps
-          - php: '8.1'
-            mode: low-deps
+        php:
+          - "8.0"
+          - "8.1"
+        dependencies:
+          - "lowest"
+          - "highest"
+
     services:
       mariadb:
         image: mariadb:latest
@@ -60,15 +61,16 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2.0.0
+      - name: "Checkout"
+        uses: actions/checkout@v3
 
-      - name: Setup PHP with PECL extension
+      - name: "Set up PHP"
         uses: shivammathur/setup-php@v2
         with:
+          coverage: none
           php-version: ${{ matrix.php }}
 
-      - name: Verify MariaDB connection
+      - name: "Verify MariaDB connection"
         env:
           PORT: ${{ job.services.mariadb.ports[3306] }}
         run: |
@@ -76,18 +78,15 @@ jobs:
             sleep 1
           done
 
-      - name: Install dependencies
-        run: |
-          if [[ "${{ matrix.mode }}" = low-deps ]]; then
-              COMPOSER_OPTION="--prefer-lowest"
-          fi
+      - name: "Install dependencies with composer"
+        uses: ramsey/composer-install@v2
+        with:
+          dependency-versions: ${{ matrix.dependencies }}
 
-          composer update --prefer-dist --no-progress ${COMPOSER_OPTION:=""}
-
-      - name: Psalm Static Analysis
+      - name: "Psalm Static Analysis"
         run: vendor/bin/psalm -c psalm.xml
 
-      - name: Unit Tests
+      - name: "Unit Tests"
         run: vendor/bin/simple-phpunit
         if: always()
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,34 @@ jobs:
       - name: "Run friendsofphp/php-cs-fixer"
         run: vendor/bin/php-cs-fixer fix --ansi --config=.php-cs-fixer.dist.php --diff --dry-run --verbose
 
-  build:
-    name: "Unit Tests"
+  static-code-analysis:
+    name: "Static Code Analysis"
+
+    runs-on: "ubuntu-latest"
+
+    strategy:
+      matrix:
+        php:
+          - "8.0"
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v3
+
+      - name: "Set up PHP"
+        uses: shivammathur/setup-php@v2
+        with:
+          coverage: none
+          php-version: ${{ matrix.php }}
+
+      - name: "Install dependencies with composer"
+        uses: ramsey/composer-install@v2
+
+      - name: "Run vimeo/psalm"
+        run: vendor/bin/psalm --diff --show-info=false --stats --threads=4
+
+  tests:
+    name: "Tests"
 
     runs-on: "ubuntu-latest"
 
@@ -83,11 +109,7 @@ jobs:
         with:
           dependency-versions: ${{ matrix.dependencies }}
 
-      - name: "Psalm Static Analysis"
-        run: vendor/bin/psalm -c psalm.xml
-
       - name: "Unit Tests"
         run: vendor/bin/simple-phpunit
-        if: always()
         env:
           TEST_DATABASE_DSN: mysql://root:password@127.0.0.1:${{ job.services.mariadb.ports[3306] }}/messenger_monitor_bundle_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,37 @@ on:
   push:
     branches:
       - master
+
 jobs:
+  coding-standards:
+    name: "Coding Standards"
+
+    runs-on: "ubuntu-latest"
+
+    strategy:
+      matrix:
+        php:
+          - "8.0"
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v3
+
+      - name: "Set up PHP"
+        uses: shivammathur/setup-php@v2
+        with:
+          coverage: none
+          php-version: ${{ matrix.php }}
+
+      - name: "Install dependencies with composer"
+        uses: ramsey/composer-install@v2
+
+      - name: "Run friendsofphp/php-cs-fixer"
+        run: vendor/bin/php-cs-fixer fix --ansi --config=.php-cs-fixer.dist.php --diff --dry-run --verbose
+
   build:
-    name: MessengerMonitor
+    name: "Unit Tests"
+
     runs-on: ubuntu-latest
 
     strategy:
@@ -30,6 +58,7 @@ jobs:
           MYSQL_DATABASE: messenger_monitor_bundle_test
           MYSQL_ROOT_PASSWORD: password
         options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2.0.0
@@ -38,7 +67,6 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          tools: php-cs-fixer
 
       - name: Verify MariaDB connection
         env:
@@ -56,12 +84,8 @@ jobs:
 
           composer update --prefer-dist --no-progress ${COMPOSER_OPTION:=""}
 
-      - name: Check src with php-cs-Fixer
-        run: php-cs-fixer fix --diff --dry-run
-
       - name: Psalm Static Analysis
         run: vendor/bin/psalm -c psalm.xml
-        if: always()
 
       - name: Unit Tests
         run: vendor/bin/simple-phpunit

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "doctrine/dbal": "^2.13.3",
         "doctrine/doctrine-bundle": "^2.0",
         "doctrine/orm": "^2.10",
+        "friendsofphp/php-cs-fixer": "^3.11",
         "symfony/browser-kit": "^5.4|^6.0",
         "symfony/css-selector": "^5.4|^6.0",
         "symfony/doctrine-messenger": "^6.0",

--- a/src/FailureReceiver/FailureReceiverName.php
+++ b/src/FailureReceiver/FailureReceiverName.php
@@ -6,6 +6,7 @@ namespace SymfonyCasts\MessengerMonitorBundle\FailureReceiver;
 
 /**
  * @internal
+ *
  * @psalm-immutable
  */
 final class FailureReceiverName

--- a/src/Storage/Doctrine/Connection.php
+++ b/src/Storage/Doctrine/Connection.php
@@ -15,6 +15,7 @@ use SymfonyCasts\MessengerMonitorBundle\Storage\Doctrine\Driver\SQLDriverInterfa
 
 /**
  * @internal
+ *
  * @final
  */
 class Connection

--- a/src/Storage/Doctrine/StoredMessageProvider.php
+++ b/src/Storage/Doctrine/StoredMessageProvider.php
@@ -10,6 +10,7 @@ use SymfonyCasts\MessengerMonitorBundle\Stamp\MonitorIdStamp;
 
 /**
  * @internal
+ *
  * @final
  */
 class StoredMessageProvider


### PR DESCRIPTION
This PR:

- requires `friendsofphp/php-cs-fixer` explicitly - I don't think making contributors jump through hoops to run php-cs-fixer locally is a good idea.
- runs this in github actions
- standardizes and updates github actions to split out static analysis to its own job