### PR TITLE
Message UUID Index for findMessage

### DIFF
--- a/src/Storage/Doctrine/Connection.php
+++ b/src/Storage/Doctrine/Connection.php
@@ -189,6 +189,7 @@ class Connection
         $table->addColumn('receiver_name', Types::STRING)->setLength(255)->setNotnull(false);
         $table->addIndex(['dispatched_at']);
         $table->addIndex(['class']);
+        $table->addIndex(['message_uid']);
         $table->setPrimaryKey(['id']);
     }
 }


### PR DESCRIPTION
Adds an index to the `message_uid` column to improve performance of the query in `findMessage`. The `findMessage` function starts to perform badly when the size of the table gets larger.

Our production `messenger_monitor` tables have quickly grown into the millions and we noticed increasingly degraded Messenger performance (messages slow to be picked up and processed) and high database CPU usage which was traced back to queries from this bundle (many were taking 5-10 seconds). After trying various other speculative approaches like increasing workers (no impact), moving messages to different priority queues (same, no impact), the consistently high CPU usage led us back here and adding this index solved our issues immediately (message processing returned to expected performance levels and database CPU usage dropped massively).

Disclaimers: I'm not familiar with this bundle, so I don't know why this function is being called, and haven't looked into if there might be other issues leading to this getting called too often perhaps? I'm also unsure if this table should be pruned at some point, is there an intention for it to be managed in some way?