### PR TITLE
Convert note into GitHub note and minor formatting tweaks in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,36 @@
 Messenger Monitor
----
+=================
 
-**THIS BUNDLE IS EXPERIMENTAL & UNSTABLE** and may not work and probably isn't ready for production.
-It's also super rough.
+> **Note**
+> **THIS BUNDLE IS EXPERIMENTAL & UNSTABLE** and may not work and probably isn't ready for production.
+> It's also super rough and currently is in a development phase.
 
-A Symfony Bundle to show you information about your Messenger queues/transports
+A Symfony Bundle to show you information about your Messenger queues/transports.
 
-This is in a development phase
+### Implemented Features
 
-Implemented Features
 * Show queue length in console (configure interval) 
 
-Planned Features
+### Planned Features
+
 * Add admin route to see the queues in the browser
 * Auto Refresh
 * Refactor queue information to allow additional data
 * Collect data (how? TBD)
 * Show more queue information (avg time, ago, ...)
 
-Phase 2
-* Realtime updates in browser (use TURTED_reactphp)
+### Phase 2
+
+* Realtime updates in the browser (use TURTED_reactphp)
 
 Installation
-============
+------------
 
 Make sure Composer is installed globally, as explained in the
 [installation chapter](https://getcomposer.org/doc/00-intro.md)
 of the Composer documentation.
 
-Applications that use Symfony Flex
-----------------------------------
+### Applications that use Symfony Flex
 
 Open a command console, enter your project directory and execute:
 
@@ -37,10 +38,9 @@ Open a command console, enter your project directory and execute:
 $ composer require symfonycasts/messenger-monitor-bundle
 ```
 
-Applications that don't use Symfony Flex
-----------------------------------------
+### Applications that don't use Symfony Flex
 
-### Step 1: Download the Bundle
+#### Step 1: Download the Bundle
 
 Open a command console, enter your project directory and execute the
 following command to download the latest stable version of this bundle:
@@ -49,7 +49,7 @@ following command to download the latest stable version of this bundle:
 $ composer require symfonycasts/messenger-monitor-bundle
 ```
 
-### Step 2: Enable the Bundle
+#### Step 2: Enable the Bundle
 
 Then, enable the bundle by adding it to the list of registered bundles
 in the `config/bundles.php` file of your project:
@@ -64,15 +64,10 @@ return [
 ```
 
 Usage
-=====
+-----
 
-```bin/console messenger:monitor``` to refresh every 3 seconds (default)
+- `bin/console messenger:monitor` to refresh every 3 seconds (default)
+- `bin/console messenger:monitor -i 0` to get the information only once
+- `bin/console messenger:monitor -i 1` to refresh every second
 
-```bin/console messenger:monitor -i 0``` to get the information only once
-```bin/console messenger:monitor -i 1``` to refresh every second
-
-Check ```bin/console help messenger:monitor``` for more information
-
-
-
-
+Check `bin/console help messenger:monitor` for more information.


### PR DESCRIPTION
Convert simple note from #52 into GitHub note to make it more noticeable:
<img width="1077" alt="Screenshot 2023-06-23 at 10 47 56" src="https://github.com/SymfonyCasts/messenger-monitor-bundle/assets/3317635/ded60afa-9da1-43b4-91a3-b720017e025f">

Also various good README formatting tweaks.
