### PR TITLE
fix: switch from Doctrine event subscriber to listener

### DIFF
--- a/src/Resources/config/doctrine.xml
+++ b/src/Resources/config/doctrine.xml
@@ -43,7 +43,7 @@
             <argument type="service_locator">
                 <argument key="SymfonyCasts\MessengerMonitorBundle\Storage\Doctrine\Connection" type="service" id="symfonycasts.messenger_monitor.storage.doctrine_connection"/>
             </argument>
-            <tag name="doctrine.event_subscriber"/>
+            <tag name="doctrine.event_listener" event="postGenerateSchema"/>
         </service>
 
         <!-- Statistics -->

--- a/src/Storage/Doctrine/EventListener/CreateSchemaListener.php
+++ b/src/Storage/Doctrine/EventListener/CreateSchemaListener.php
@@ -4,16 +4,14 @@ declare(strict_types=1);
 
 namespace SymfonyCasts\MessengerMonitorBundle\Storage\Doctrine\EventListener;
 
-use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
-use Doctrine\ORM\Tools\ToolEvents;
 use Psr\Container\ContainerInterface;
 use SymfonyCasts\MessengerMonitorBundle\Storage\Doctrine\Connection;
 
 /**
  * @internal
  */
-final class CreateSchemaListener implements EventSubscriber
+final class CreateSchemaListener
 {
     public function __construct(private ContainerInterface $container)
     {
@@ -25,16 +23,5 @@ final class CreateSchemaListener implements EventSubscriber
             $event->getSchema(),
             $event->getEntityManager()->getConnection()
         );
-    }
-
-    public function getSubscribedEvents(): array
-    {
-        if (!class_exists(ToolEvents::class)) {
-            return [];
-        }
-
-        return [
-            ToolEvents::postGenerateSchema,
-        ];
     }
 }


### PR DESCRIPTION
Event subscribers are deprecated in orm 2.x and removed in 3.x.